### PR TITLE
Type 3 chunk extended timestamp

### DIFF
--- a/chunk_header.go
+++ b/chunk_header.go
@@ -172,6 +172,8 @@ func decodeChunkMessageHeader(r io.Reader, fmt byte, buf []byte, mh *chunkMessag
 			}
 			mh.timestampDelta = binary.BigEndian.Uint32(cache32bits)
 		}
+		// maintain timestamp mode while no 0 | 1 | 2 fmts
+		mh.extendedTimestampMode = extendedTimestampMode
 
 	default:
 		panic("Unexpected fmt")

--- a/chunk_stream_reader.go
+++ b/chunk_stream_reader.go
@@ -11,6 +11,14 @@ import (
 	"bytes"
 )
 
+type ExtendedTimestampMode byte
+
+const (
+	ExtendedTimestampUnused    ExtendedTimestampMode = 0
+	ExtendedTimestampUsed      ExtendedTimestampMode = 1
+	ExtendedTimestampDeltaUsed ExtendedTimestampMode = 2
+)
+
 type ChunkStreamReader struct {
 	basicHeader   chunkBasicHeader
 	messageHeader chunkMessageHeader
@@ -20,6 +28,8 @@ type ChunkStreamReader struct {
 	messageLength   uint32 // max, 24bits
 	messageTypeID   byte
 	messageStreamID uint32
+
+	extendedTimestampMode ExtendedTimestampMode
 
 	buf       bytes.Buffer
 	completed bool


### PR DESCRIPTION
Actually [da024bc](https://github.com/GetStream/go-rtmp/pull/1/commits/da024bc93f8d2225747f5bcc3a67fa3f84be29b0) doesn't fix anything, the last value is passed around in reader obj, so everything is correct in jbreich fix